### PR TITLE
Use c_free for memory that has been allocated with c_malloc and c_calloc

### DIFF
--- a/osqp_mex.cpp
+++ b/osqp_mex.cpp
@@ -453,13 +453,13 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         }
 
         // Free vectors
-        if(!mxIsEmpty(q)) mxFree(q_vec);
-        if(!mxIsEmpty(l)) mxFree(l_vec);
-        if(!mxIsEmpty(u)) mxFree(u_vec);
-        if(!mxIsEmpty(Px)) mxFree(Px_vec);
-        if(!mxIsEmpty(Ax)) mxFree(Ax_vec);
-        if(!mxIsEmpty(Px_idx)) mxFree(Px_idx_vec);
-        if(!mxIsEmpty(Ax_idx)) mxFree(Ax_idx_vec);
+        if(!mxIsEmpty(q)) c_free(q_vec);
+        if(!mxIsEmpty(l)) c_free(l_vec);
+        if(!mxIsEmpty(u)) c_free(u_vec);
+        if(!mxIsEmpty(Px)) c_free(Px_vec);
+        if(!mxIsEmpty(Ax)) c_free(Ax_vec);
+        if(!mxIsEmpty(Px_idx)) c_free(Px_idx_vec);
+        if(!mxIsEmpty(Ax_idx)) c_free(Ax_idx_vec);
 
         // Report errors (if any)
         switch (exitflag) {
@@ -513,8 +513,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         osqp_warm_start(osqpData->work, x_vec, y_vec);
 
         // Free vectors
-        if(!mxIsEmpty(x)) mxFree(x_vec);
-        if(!mxIsEmpty(y)) mxFree(y_vec);
+        if(!mxIsEmpty(x)) c_free(x_vec);
+        if(!mxIsEmpty(y)) c_free(y_vec);
 
         return;
     }
@@ -544,7 +544,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         osqp_warm_start_x(osqpData->work, x_vec);
 
         // Free vectors
-        if(!mxIsEmpty(x)) mxFree(x_vec);
+        if(!mxIsEmpty(x)) c_free(x_vec);
 
         return;
     }
@@ -574,7 +574,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         osqp_warm_start_y(osqpData->work, y_vec);
 
         // Free vectors
-        if(!mxIsEmpty(y)) mxFree(y_vec);
+        if(!mxIsEmpty(y)) c_free(y_vec);
 
         return;
     }

--- a/osqp_mex.cpp
+++ b/osqp_mex.cpp
@@ -308,17 +308,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
         //cleanup temporary structures
         // Data
-        if (data->q)  mxFree(data->q);
-        if (data->l)  mxFree(data->l);
-        if (data->u)  mxFree(data->u);
-        if (Px)       mxFree(Px);
-        if (Pi)       mxFree(Pi);
-        if (Pp)       mxFree(Pp);
-        if (data->P)  mxFree(data->P);
-        if (Ax)       mxFree(Ax);
-        if (Ai)       mxFree(Ai);
-        if (Ap)       mxFree(Ap);
-        if (data->A)  mxFree(data->A);
+        if (data->q)  c_free(data->q);
+        if (data->l)  c_free(data->l);
+        if (data->u)  c_free(data->u);
+        if (Px)       c_free(Px);
+        if (Pi)       c_free(Pi);
+        if (Pp)       c_free(Pp);
+        if (data->P)  c_free(data->P);
+        if (Ax)       c_free(Ax);
+        if (Ai)       c_free(Ai);
+        if (Ap)       c_free(Ap);
+        if (data->A)  c_free(data->A);
         if (data)     mxFree(data);
         // Settings
         if (settings) mxFree(settings);


### PR DESCRIPTION
I was compiling the osqp_mex function against an already compiled osqp version (similar to what was described in https://github.com/oxfordcontrol/osqp-matlab/issues/27), and my MATLAB was crashing because quantities that were allocated with `c_malloc` and `c_calloc` were then freed with `mxFree`.

While the direct use of  `c_malloc` and `c_calloc`  can be converted to the corresponding `mx**` allocator by defining `MATLAB`  for the osqp_mex compilation unit, this was not possible for the allocation done via [`csc_matrix`](https://github.com/oxfordcontrol/osqp/blob/da403d4b41e86b7dc00237047ea4f00354d902ed/src/cs.c#L12), as fhat function is compiled as part of OSQP and whose definition can't be changed.

Changing to use `c_free` for freeing all the memory that was allocated with  `c_malloc` and `c_calloc` fixes the problem, and works as expected even if `MATLAB` is defined, as in the case of the official build procedure for the MATLAB bindings. 